### PR TITLE
Client scopes and Urls ctors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+
+## [1.1.1] - 2024-07-23
+
+### Updates
+- Added `Client.Urls` ctor for common used client urls.
+- Added `Client.Scope` struct to replace the string based scopes declaration when instantiating a `Client`. 
+
+
+
 ## [1.1.0] - 2024-06-10
 
 ### Updates
@@ -8,8 +17,4 @@
 
 ### Breaking Changes
 - `OAuth2Grant` ctors change. Creating a grant doesn't require providing the client, or any identifiers. It is now handled internally. <br />
-If you use the `AuthorizationService` methods that hide the underlying grant e.g. `login(username:password:)`, this change will not affect you.
-
-
-## [version < 1.1.0]
-The first Changelog file created at v 1.1.0, so no info before.. sorry!
+If you only use the `AuthorizationService` methods that hide the underlying grant e.g. `login(username:password:)`, this change will not affect you.

--- a/Sources/Indice.Identity/Client/IdentityClient.swift
+++ b/Sources/Indice.Identity/Client/IdentityClient.swift
@@ -16,8 +16,8 @@ public protocol IdentityClient: AnyObject {
     typealias Errors  = IdentityClientErrors
     typealias Options = IdentityClientOptions
     
-    var tokens: TokenStorageAccessor { get }
-    var networkClient: NetworkClient { get }
+    var tokens: TokenStorageAccessor    { get }
+    var networkClient: RequestProcessor { get }
     
     var authorizationService      : AuthorizationService      { get }
     var userService               : UserService               { get }

--- a/Sources/Indice.Identity/Client/IdentityClientImplementation.swift
+++ b/Sources/Indice.Identity/Client/IdentityClientImplementation.swift
@@ -74,7 +74,7 @@ internal class IdentityClientImpl: IdentityClient {
     
     public
     private(set) lazy
-    var networkClient: NetworkClient = {
+    var networkClient: RequestProcessor = {
         self.createNetworkClient(self)
     }()
     

--- a/Sources/Indice.Identity/Client/Services/AuthorizationService.swift
+++ b/Sources/Indice.Identity/Client/Services/AuthorizationService.swift
@@ -233,7 +233,7 @@ internal class AuthorizationServiceImpl: AuthorizationService {
         
         let queryParams = ["client_id"      : client.id,
                            "client_secret"  : client.secret,
-                           "scope"          : client.userScope,
+                           "scope"          : client.userScope.value,
                            "redirect_uri"   : client.urls.authorization,
                            "response_type"  : configuration.authCodeResponseType,
                            "response_mode"  : configuration.authCodeResponseMode,

--- a/Sources/Indice.Identity/Client/Services/DevicesService.swift
+++ b/Sources/Indice.Identity/Client/Services/DevicesService.swift
@@ -379,9 +379,10 @@ extension DevicesServiceImpl {
         
         let swapDeviceId: String? = await {
             if currentTrustedCount >= identityOptions.maxTrustedDevicesCount {
-                if case .swap(let deviceInfo) = await deviceSelection(devices) {
+                switch await deviceSelection(devices) {
+                case .swap(let deviceInfo):
                     return deviceInfo.deviceId
-                } else {
+                case .aborted:
                     // TODO: this should throw something here?
                     return nil
                 }

--- a/Sources/Indice.Identity/Models/Extensions/DeviceAuthenticationExtensions.swift
+++ b/Sources/Indice.Identity/Models/Extensions/DeviceAuthenticationExtensions.swift
@@ -60,7 +60,7 @@ internal extension DeviceAuthentication.AuthorizationRequest {
                      device_id: ids.device,
                      mode: mode,
                      client_id: client.id,
-                     scope: client.userScope,
+                     scope: client.userScope.value,
                      registration_id: try {
                          if requiresRegId && ids.registration == nil {
                              throw IdentityClient.Errors.TrustDevice

--- a/Sources/Indice.Identity/Models/Responses/DeviceInfo.swift
+++ b/Sources/Indice.Identity/Models/Responses/DeviceInfo.swift
@@ -9,19 +9,19 @@ import Foundation
 
 public struct DeviceInfo: Codable, Equatable {
     
-    public var deviceId: String? = nil
-    public var name: String? = nil
-    public var platform: DevicePlatform? = nil
-    public var isPushNotificationsEnabled: Bool? = nil
-    public var supportsPinLogin: Bool? = nil
-    public var supportsFingerprintLogin: Bool? = nil
-    public var model: String? = nil
-    public var osVersion: String? = nil
-    public var data: String? = nil
-    public var dateCreated: Date? = nil
-    public var lastSignInDate: Date? = nil
-    public var isTrusted: Bool? = nil
-    public var trustActivationDate: Date? = nil
-    public var canActivateDeviceTrust: Bool? = nil
-    public var clientType: DeviceClientType? = nil
+    public var deviceId: String?
+    public var name: String?
+    public var platform: DevicePlatform?
+    public var isPushNotificationsEnabled: Bool?
+    public var supportsPinLogin: Bool?
+    public var supportsFingerprintLogin: Bool?
+    public var model: String?
+    public var osVersion: String?
+    public var data: String?
+    public var dateCreated: Date?
+    public var lastSignInDate: Date?
+    public var isTrusted: Bool?
+    public var trustActivationDate: Date?
+    public var canActivateDeviceTrust: Bool?
+    public var clientType: DeviceClientType?
 }

--- a/Sources/Indice.Identity/Protocols/Client.swift
+++ b/Sources/Indice.Identity/Protocols/Client.swift
@@ -12,6 +12,10 @@ import Foundation
  */
 public struct Client {
     
+    public struct Scope {
+        let value: String
+    }
+    
     /** Client urls. Authorization Urls and Post Logout url. */
     public struct Urls {
         public var authorization: String? = nil
@@ -21,20 +25,44 @@ public struct Client {
             self.authorization = authorization
             self.postLogout = postLogout
         }
+        
+        ///Creates a Urls based on the default common values used most of the time
+        ///
+        ///It is the equivalent of:
+        ///
+        ///      Urls.init(authorization: "\(redirectScheme)://auth-callback",
+        ///                postLogout:    "\(redirectScheme)://post-logout")
+        public init(commonForRedirectScheme redirectScheme: String) {
+            self.authorization = "\(redirectScheme)://auth-callback"
+            self.postLogout    = "\(redirectScheme)://post-logout"
+        }
     }
     
     /** Client ID */
-    public let id     : String
+    public let id         : String
     /** Client Secret - Creating a public client deems the secret redundant, */
-    public let secret : String?
+    public let secret     : String?
     /** Client Scope */
-    public let userScope  : String
+    public let userScope  : [Scope]
     /** Client Scope */
-    public let appScope   : String
+    public let appScope   : [Scope]
     /** Client urls. Authorization Urls and Post Logout url. */
-    public let urls   : Urls
+    public let urls       : Urls
     
+    @available(*, deprecated, message: "Use the new ctor that accepts a collection of Client.Scope")
     public init(id: String, secret: String?, userScope: String, appScope: String, urls: Urls) {
+        func splitScopes(_ scopes: String) -> [Client.Scope] {
+            scopes.components(separatedBy: .whitespaces).map(Client.Scope.init(value:))
+        }
+        
+        self.id = id
+        self.secret = secret
+        self.userScope = splitScopes(userScope)
+        self.appScope = splitScopes(appScope)
+        self.urls = urls
+    }
+    
+    public init(id: String, secret: String?, userScope: [Scope], appScope: [Scope], urls: Urls) {
         self.id = id
         self.secret = secret
         self.userScope = userScope
@@ -44,12 +72,29 @@ public struct Client {
 }
 
 
+extension Client.Scope: ExpressibleByStringLiteral {
+    public init(stringLiteral value: StringLiteralType) {
+        self.value = value
+    }
+}
+
+extension Client.Scope {
+    public static let profile          : Self = "profile"
+    public static let openId           : Self = "openid"
+    public static let email            : Self = "email"
+    public static let phone            : Self = "phone"
+    public static let role             : Self = "role"
+    public static let offlineAccess    : Self = "offline_access"
+    public static let identity         : Self = "identity"
+}
+
+
 public extension Client {
     /** Provides the basic auth header for the specific client */
-    var basicAuth: String { get {
+    var basicAuth: String {
        "Basic " +
             (id + ":" + (secret ?? ""))
                 .data(using: .utf8)!
                 .base64EncodedString()
-    } }
+    }
 }

--- a/Sources/Indice.Identity/Protocols/Grant.swift
+++ b/Sources/Indice.Identity/Protocols/Grant.swift
@@ -71,7 +71,7 @@ internal extension OAuth2Grant {
                   ? client.userScope
                   : client.appScope
         
-        let extras: Params = ["scope"         : scope,
+        let extras: Params = ["scope"         : scope.value,
                               "client_id"     : client.id,
                               "client_secret" : client.secret]
                                   .compactMapValues { $0 }

--- a/Sources/Indice.Identity/Utilities/CollectionExtensions.swift
+++ b/Sources/Indice.Identity/Utilities/CollectionExtensions.swift
@@ -18,3 +18,18 @@ extension Collection {
         return self
     }
 }
+
+extension Collection where Element == Client.Scope {
+    
+    var value: String {
+        self.map(\.value).joined(separator: " ")
+    }
+
+    public static var defaultUserScopes: [Element] { [.profile,
+                                                      .openId,
+                                                      .email,
+                                                      .phone,
+                                                      .role,
+                                                      .offlineAccess,
+                                                      .identity] }
+}


### PR DESCRIPTION
### [Add]
- Client.Urls 
New ctor instantiating the struct with the default url paths used commonly on Identity.Clients' setup.
- Client.Scope 
Typed struct to replace string based declaration of the Client's scopes, with the most common ones as static params to avoid mistypes.
